### PR TITLE
Removed the unnecessary decorator above extract_mfcc_delta and delta_…

### DIFF
--- a/AFX/extractors/cepstral_features.py
+++ b/AFX/extractors/cepstral_features.py
@@ -113,7 +113,6 @@ def extract_mfcc(
         return {'mfcc': mfcc, 'metadata': {'times': times}}
     return result
 
-@framewise_extractor
 def extract_mfcc_delta(
     signal: np.ndarray,
     sr: int,
@@ -219,7 +218,6 @@ def extract_mfcc_delta(
     return result
 
 
-@framewise_extractor
 def extract_mfcc_delta_delta(
     signal: np.ndarray,
     sr: int,


### PR DESCRIPTION
…delta, keeping its logic

The issue:
The decorator slices the input signal into single-frame chunks whenever frame_size and hop_length are provided. Each chunk is 2048 samples long per the config (config.json). Delta computation then operates on an MFCC array with n_frames=1. Due to the logic in compute_delta (lines 67‑75 in AFX/methods/delta.py), such short sequences result in a width less than three and return an array of zeros, not informative deltas.